### PR TITLE
CMake: revert to 2.8.11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,11 +4,11 @@
 #   Francois Gindraud (2017)
 # Created: 22/08/2009
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required (VERSION 2.8.11)
 project (bppsuite CXX)
 
 # Compile options
-set (private-compile-options -std=c++11 -Wall -Weffc++ -Wshadow -Wconversion)
+set (CMAKE_CXX_FLAGS "-std=c++11 -Wall -Weffc++ -Wshadow -Wconversion")
 
 IF(NOT CMAKE_BUILD_TYPE)
   SET(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING
@@ -35,7 +35,7 @@ IF(NOT BUILD_STATIC)
 ENDIF()
 IF(BUILD_STATIC)
   MESSAGE("-- Static linkage requested.")
-  set (private-compile-options -static -static-libgcc ${private-compile-options})
+  set (CMAKE_CXX_FLAGS "-static -static-libgcc ${CMAKE_CXX_FLAGS}")
 ENDIF()
 
 # Find dependencies (add install directory to search)
@@ -65,54 +65,13 @@ SET(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/COPYING.txt")
 SET(CPACK_RESOURCE_FILE_AUTHORS "${CMAKE_SOURCE_DIR}/AUTHORS.txt")
 SET(CPACK_RESOURCE_FILE_INSTALL "${CMAKE_SOURCE_DIR}/INSTALL.txt")
 SET(CPACK_SOURCE_GENERATOR "TGZ")
-SET(CPACK_SOURCE_IGNORE_FILES
- "CMakeFiles"
- "Makefile"
- "_CPack_Packages"
- "CMakeCache.txt"
- ".*\\\\.cmake"
- ".*\\\\.git"
- ".*\\\\.gz"
- ".*\\\\.zip"
- ".*\\\\.deb"
- ".*\\\\.rpm"
- ".*\\\\.dmg"
- ".*\\\\.sh"
- ".*\\\\..*\\\\.swp"
- ".*stamp"
- "\\\\.sh"
- "bppSuite/\\\\..*"
- "bppSuite/bppancestor"
- "bppSuite/bppml"
- "bppSuite/bppphysamp"
- "bppSuite/bppseqman"
- "bppSuite/bppconsense"
- "bppSuite/bppreroot"
- "bppSuite/bpppars"
- "bppSuite/bpptreedraw"
- "bppSuite/bppdist"
- "bppSuite/bppseqgen"
- "bppSuite/bppalnscore"
- "doc/bppsuite/"
- "doc/bppsuite\\\\.info"
- "doc/bppsuite\\\\.toc"
- "doc/bppsuite\\\\.vr"
- "doc/bppsuite\\\\.tp"
- "doc/bppsuite\\\\.log"
- "doc/bppsuite\\\\.fn"
- "doc/bppsuite\\\\.ky"
- "doc/bppsuite\\\\.cp"
- "doc/bppsuite\\\\.pg"
- "doc/bppsuite\\\\.aux"
- "doc/bppsuite\\\\.pdf"
- "man/.*\\\\.1.${DOC_COMPRESS_EXT}"
- "install_manifest.txt"
- "DartConfiguration.tcl"
- ${CPACK_SOURCE_IGNORE_FILES}
-)
-IF (MACOS)
-  SET(CPACK_GENERATOR "Bundle")
-ENDIF()
+# /!\ This assumes that an external build is used
+SET(CPACK_SOURCE_IGNORE_FILES 
+       "/build/" 
+       "/\\\\.git/" 
+       "/\\\\.gitignore" 
+       ${CPACK_SOURCE_IGNORE_FILES}
+       )
 
 SET(CPACK_SOURCE_PACKAGE_FILE_NAME "${CMAKE_PROJECT_NAME}-${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}")
 SET(CPACK_DEBSOURCE_PACKAGE_FILE_NAME "${CMAKE_PROJECT_NAME}_${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}.orig")
@@ -120,14 +79,6 @@ INCLUDE(CPack)
 
 #This adds the 'dist' target
 ADD_CUSTOM_TARGET(dist COMMAND ${CMAKE_MAKE_PROGRAM} package_source)
-# 'clean' is not (yet) a first class target. However, we need to clean the directories before building the sources:
-IF("${CMAKE_GENERATOR}" MATCHES "Make")
-  ADD_CUSTOM_TARGET(make_clean
-    COMMAND ${CMAKE_MAKE_PROGRAM} clean
-    WORKING_DIRECTORY ${CMAKE_CURRENT_DIR}
-  )
-  ADD_DEPENDENCIES(dist make_clean)
-ENDIF()
 
 IF(NOT NO_DEP_CHECK)
 IF (UNIX)

--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -1,4 +1,4 @@
-This software needs cmake >= 2.8.12 and a C++11 capable compiler to build
+This software needs cmake >= 2.8.11 and a C++11 capable compiler to build
 
 After installing cmake, run it with the following command:
 $ cmake -DCMAKE_INSTALL_PREFIX=[where to install, for instance /usr/local or $HOME/.local] .

--- a/bppSuite/CMakeLists.txt
+++ b/bppSuite/CMakeLists.txt
@@ -42,8 +42,6 @@ foreach (target ${bppsuite-targets})
   else (BUILD_STATIC)
     target_link_libraries (${target} ${BPP_LIBS_SHARED})
   endif (BUILD_STATIC)
-  # Private compile flags
-  target_compile_options (${target} PRIVATE ${private-compile-options})
 endforeach (target)
 
 install (TARGETS ${bppsuite-targets} DESTINATION bin)


### PR DESCRIPTION
Redhat seems stuck with 2.8.11.
-> Removing the 2.8.12 feature of using target_compile_options.
-> Using the old set CMAKE_CXX_FLAGS

Also simplified the CPACK ignored files.