### PR TITLE
CMake: use GNUInstallDirs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,11 +38,42 @@ IF(BUILD_STATIC)
   SET(CMAKE_CXX_FLAGS "-static -static-libgcc ${CMAKE_CXX_FLAGS}")
 ENDIF()
 
+# Check compression program
+# COMPRESS_PROGRAM controls the choice of program
+# COMPRESS_EXT can be used to override the file extension
+if (NOT COMPRESS_PROGRAM)
+  set (COMPRESS_PROGRAM gzip CACHE STRING "Set program for compressing documentation" FORCE)
+endif ()
+find_program (COMPRESS_BIN NAMES ${COMPRESS_PROGRAM} DOC "${COMPRESS_PROGRAM} compression program")
+if (NOT COMPRESS_BIN)
+  message (STATUS "${COMPRESS_PROGRAM} program not found, text doc will not be compressed")
+else ()
+  # Deduce COMPRESS_EXT for known compression programs if not set
+  if (NOT COMPRESS_EXT)
+    if (${COMPRESS_PROGRAM} STREQUAL "gzip")
+      set (COMPRESS_EXT "gz")
+    elseif (${COMPRESS_PROGRAM} STREQUAL "bzip2")
+      set (COMPRESS_EXT "bz2")
+    else ()
+      set (COMPRESS_EXT "${COMPRESS_PROGRAM}") # Default: program name (works for xz/lzma)
+    endif ()
+  endif ()
+  # Generate command line args (always add -c to output compressed file to stdout)
+  if (${COMPRESS_PROGRAM} STREQUAL "gzip")
+    # -n for no timestamp in files (reproducible builds)
+    set (COMPRESS_ARGS -c -n)
+  else ()
+    set (COMPRESS_ARGS -c)
+  endif ()
+  message (STATUS "Found ${COMPRESS_BIN} compression program, using file extension .${COMPRESS_EXT}")
+endif ()
+
 # Find dependencies (add install directory to search)
 if (CMAKE_INSTALL_PREFIX)
   set (CMAKE_PREFIX_PATH "${CMAKE_INSTALL_PREFIX}" ${CMAKE_PREFIX_PATH})
 endif (CMAKE_INSTALL_PREFIX)
 
+include (GNUInstallDirs)
 find_package (bpp-phyl 11.0.0 REQUIRED)
 find_package (bpp-popgen 7.0.0 REQUIRED)
 

--- a/bppSuite/CMakeLists.txt
+++ b/bppSuite/CMakeLists.txt
@@ -44,4 +44,4 @@ foreach (target ${bppsuite-targets})
   endif (BUILD_STATIC)
 endforeach (target)
 
-install (TARGETS ${bppsuite-targets} DESTINATION bin)
+install (TARGETS ${bppsuite-targets} DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/bppsuite.spec
+++ b/bppsuite.spec
@@ -38,14 +38,14 @@ AutoProv: yes
 %if 0%{?mdkversion}
 %if 0%{?mdkversion} >= 201100
 BuildRequires: xz
-%define zipext xz
+%define compress_program xz
 %else
 BuildRequires: lzma
-%define zipext lzma
+%define compress_program lzma
 %endif
 %else
 BuildRequires: gzip
-%define zipext gz
+%define compress_program gzip
 %endif
 
 %description
@@ -67,21 +67,10 @@ Bio++ program suite includes programs:
 %setup -q
 
 %build
-CFLAGS="-I%{_prefix}/include $RPM_OPT_FLAGS"
-CMAKE_FLAGS="-DCMAKE_INSTALL_PREFIX=%{_prefix}"
-if [ %{_lib} == 'lib64' ] ; then
-  CMAKE_FLAGS="$CMAKE_FLAGS -DLIB_SUFFIX=64"
-fi
-if [ %{zipext} == 'lzma' ] ; then
-  CMAKE_FLAGS="$CMAKE_FLAGS -DDOC_COMPRESS=lzma -DDOC_COMPRESS_EXT=lzma"
-fi
-if [ %{zipext} == 'xz' ] ; then
-  CMAKE_FLAGS="$CMAKE_FLAGS -DDOC_COMPRESS=xz -DDOC_COMPRESS_EXT=xz"
-fi
-
+CFLAGS="$RPM_OPT_FLAGS"
+CMAKE_FLAGS="-DCMAKE_INSTALL_PREFIX=%{_prefix} -DCOMPRESS_PROGRAM=%{compress_program}"
 cmake $CMAKE_FLAGS .
 make
-make info
 
 %install
 make DESTDIR=$RPM_BUILD_ROOT install
@@ -96,31 +85,9 @@ rm -rf $RPM_BUILD_ROOT
 %files
 %defattr(-,root,root)
 %doc AUTHORS.txt COPYING.txt INSTALL.txt ChangeLog
-%{_prefix}/bin/bppml
-%{_prefix}/bin/bppseqgen
-%{_prefix}/bin/bppancestor
-%{_prefix}/bin/bppdist
-%{_prefix}/bin/bpppars
-%{_prefix}/bin/bppseqman
-%{_prefix}/bin/bppconsense
-%{_prefix}/bin/bppreroot
-%{_prefix}/bin/bpptreedraw
-%{_prefix}/bin/bppalnscore
-%{_prefix}/bin/bpppopstats
-%{_prefix}/bin/bppmixedlikelihoods
-%{_prefix}/share/info/bppsuite.info.%{zipext}
-%{_prefix}/share/man/man1/bppml.1.%{zipext}
-%{_prefix}/share/man/man1/bppseqgen.1.%{zipext}
-%{_prefix}/share/man/man1/bppancestor.1.%{zipext}
-%{_prefix}/share/man/man1/bpppars.1.%{zipext}
-%{_prefix}/share/man/man1/bppdist.1.%{zipext}
-%{_prefix}/share/man/man1/bppconsense.1.%{zipext}
-%{_prefix}/share/man/man1/bppseqman.1.%{zipext}
-%{_prefix}/share/man/man1/bppreroot.1.%{zipext}
-%{_prefix}/share/man/man1/bpptreedraw.1.%{zipext}
-%{_prefix}/share/man/man1/bppalnscore.1.%{zipext}
-%{_prefix}/share/man/man1/bpppopstats.1.%{zipext}
-%{_prefix}/share/man/man1/bppmixedlikelihoods.1.%{zipext}
+%{_prefix}/bin/*
+%{_prefix}/share/info/*.info*
+%{_prefix}/share/man/man1/*.1*
 
 %changelog
 * Tue Jun 06 2017 Julien Dutheil <julien.dutheil@univ-montp2.fr> 2.3.1-1

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -12,12 +12,12 @@
 find_program (MAKEINFO NAMES makeinfo texi2any DOC "makeinfo doc generator program")
 if (NOT MAKEINFO)
   message (STATUS "makeinfo program not found: 'info' and 'html' target disabled (builds info/html doc)")
-else (NOT MAKEINFO)
-  message (STATUS "Found makeinfo as '${MAKEINFO}': 'info' and 'html' target enabled (builds info/html doc)")
+else ()
+  message (STATUS "Found ${MAKEINFO}: 'info' and 'html' target enabled (builds info/html doc)")
 
   set (input ${CMAKE_CURRENT_SOURCE_DIR}/bppsuite.texi)
 
-  # Build and install info page
+  # Build info page
   set (output ${CMAKE_CURRENT_BINARY_DIR}/bppsuite.info)
   add_custom_command (
     OUTPUT ${output}
@@ -26,10 +26,25 @@ else (NOT MAKEINFO)
     COMMENT "Generating info page"
     VERBATIM
     )
-  install (FILES ${output} DESTINATION share/info)
 
-  # Add "info" target, built with "all" (needed because install will fail if not built).
-  add_custom_target (info ALL DEPENDS ${output})
+  # Install, and have "info" built with "all" (install needs the file to be built)
+  if (NOT COMPRESS_BIN)
+    # Install uncompressed info page
+    install (FILES ${output} DESTINATION ${CMAKE_INSTALL_INFODIR})
+    add_custom_target (info ALL DEPENDS ${output})
+  else ()
+    # Compress and install compressed file
+    set (compressed_ouput ${output}.${COMPRESS_EXT})
+    add_custom_command (
+      OUTPUT ${compressed_ouput}
+      COMMAND ${COMPRESS_BIN} ${COMPRESS_ARGS} ${output} > ${compressed_ouput}
+      DEPENDS ${output}
+      COMMENT "Compressing info page"
+      VERBATIM
+      )
+    install (FILES ${compressed_ouput} DESTINATION ${CMAKE_INSTALL_INFODIR})
+    add_custom_target (info ALL DEPENDS ${compressed_ouput})
+  endif ()
 
   # Also provide a "html" target that builds html doc (not installed, and not part of "all").
   set (output ${CMAKE_CURRENT_BINARY_DIR}/bppsuite.html)
@@ -56,6 +71,5 @@ else (NOT MAKEINFO)
       VERBATIM
       )
     add_custom_target (pdf DEPENDS ${output})
-  endif (TEXIDVI)
-endif (NOT MAKEINFO)
-
+  endif ()
+endif ()

--- a/man/CMakeLists.txt
+++ b/man/CMakeLists.txt
@@ -5,32 +5,33 @@
 # Created: 22/08/2009
 
 # Build manpages.
-# In practice, they are just compressed from the text files using gzip.
-# Manpages are built and installed as part of "all" if gzip is found.
+# In practice, they are just compressed from the text files using COMPRESS_PROGRAM
+# Manpages are built and installed as part of "all" if a COMPRESS_PROGRAM is found.
 
-find_program (GZIP NAMES gzip DOC "gzip compression program")
-if (NOT GZIP)
-  message (STATUS "gzip program not found: 'man' target disabled (builds manpages)")
-else (NOT GZIP)
-  message (STATUS "Found gzip as '${GZIP}': 'man' target enabled (builds manpages)")
+# Take all manpages files in the directory
+file (GLOB manpage_files RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.1)
 
+if (NOT COMPRESS_BIN)
+  # Just install manpages from source
+  foreach (manpage_file ${manpage_files})
+    install (FILES ${CMAKE_CURRENT_SOURCE_DIR}/${manpage_file} DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
+  endforeach (manpage_file)
+else ()
   # Create a list of manpage targets
   set (manpage-targets)
 
-  # Take all manpages files in the directory
-  file (GLOB manpage_files RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.1)
   foreach (manpage_file ${manpage_files})
-    # Compress manpage, install, add to manpage list
+    # Compress manpage, install, add to manpage target list
     set (input ${CMAKE_CURRENT_SOURCE_DIR}/${manpage_file})
-    set (output ${CMAKE_CURRENT_BINARY_DIR}/${manpage_file}.gz)
+    set (output ${CMAKE_CURRENT_BINARY_DIR}/${manpage_file}.${COMPRESS_EXT})
     add_custom_command (
       OUTPUT ${output}
-      COMMAND ${GZIP} -c ${input} > ${output}
+      COMMAND ${COMPRESS_BIN} ${COMPRESS_ARGS} ${input} > ${output}
       DEPENDS ${input}
       COMMENT "Compressing manpage ${manpage_file}"
       VERBATIM
       )
-    install (FILES ${output} DESTINATION share/man/man1)
+    install (FILES ${output} DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
     list (APPEND manpage-targets ${output})
     unset (input)
     unset (output)
@@ -38,4 +39,4 @@ else (NOT GZIP)
 
   # Add target "man", built with "all" (needed because install will fail if not built).
   add_custom_target (man ALL DEPENDS ${manpage-targets})
-endif (NOT GZIP)
+endif ()


### PR DESCRIPTION
Better support distrib-specific paths by using the CMake standard module
GNUInstallDirs.
This modules defines distrib specific install paths.
Use bindir for binaries.
Also use mandir/infodir for man/info pages.
Both man and info pages are now compressed if a compression program is
available.
Reestablished support for multiple compression programs.
Also updated .spec file to reflect the new paths and compression program
system.